### PR TITLE
Add patch-based temporal transformer for single-camera temporal modeling

### DIFF
--- a/temporal_transformer.py
+++ b/temporal_transformer.py
@@ -1,46 +1,73 @@
 import torch
 import torch.nn as nn
 
+
 class TemporalTransformer(nn.Module):
-    """Simple temporal transformer for frame sequences."""
-    def __init__(self, in_channels: int = 3, d_model: int = 128, nhead: int = 8,
-                 dim_feedforward: int = 256, dropout: float = 0.1,
-                 num_layers: int = 3, max_len: int = 100):
+    """Temporal transformer for sequences of video frames.
+
+    Each frame is split into non-overlapping patches which are embedded and
+    processed by a stack of Transformer encoder layers. The module outputs a
+    temporal feature vector for every frame in the sequence. This implementation
+    is lightweight and suited for single-camera inputs.
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        d_model: int = 128,
+        nhead: int = 8,
+        dim_feedforward: int = 256,
+        dropout: float = 0.1,
+        num_layers: int = 3,
+        patch_size: int = 16,
+        max_len: int = 100,
+    ) -> None:
         super().__init__()
-        # Feature embedding: global average pool then linear projection
-        self.embed = nn.Sequential(
-            nn.AdaptiveAvgPool2d((1, 1)),
-            nn.Flatten(),
-            nn.Linear(in_channels, d_model)
-        )
-        # Positional encoding parameter
+
+        # Patch embedding: conv projection + flatten
+        self.proj = nn.Conv2d(in_channels, d_model, kernel_size=patch_size, stride=patch_size)
+        self.flatten = nn.Flatten(2)  # (N, d_model, num_patches)
+
+        # Positional encoding for the temporal dimension
         self.pos_embedding = nn.Parameter(torch.zeros(max_len, d_model))
-        # Transformer encoder
+
+        # Transformer encoder operating on frame-level embeddings
         encoder_layer = nn.TransformerEncoderLayer(
             d_model=d_model,
             nhead=nhead,
             dim_feedforward=dim_feedforward,
             dropout=dropout,
-            batch_first=True
+            batch_first=True,
         )
         self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
-        # Output head
+
+        # Output head mapping to temporal features
         self.head = nn.Linear(d_model, d_model)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward pass.
+        """Compute temporal features from a sequence of frames.
 
         Args:
-            x: Tensor of shape (T, C, H, W)
+            x: Tensor of shape ``(T, C, H, W)`` containing ``T`` RGB frames.
+
         Returns:
-            Tensor of shape (T, d_model) representing temporal features.
+            Tensor of shape ``(T, d_model)`` with the temporal embedding for
+            each frame in the input sequence.
         """
-        # x -> (T, d_model)
-        x = self.embed(x)
-        # Add positional encoding
-        pos = self.pos_embedding[:x.size(0)]
+
+        # Convert frames to patch embeddings -> (T, d_model, num_patches)
+        x = self.proj(x)
+        x = self.flatten(x).transpose(1, 2)  # (T, num_patches, d_model)
+
+        # Aggregate patch tokens into a single feature per frame
+        x = x.mean(dim=1)
+
+        # Add learnable temporal positional encoding
+        pos = self.pos_embedding[: x.size(0)]
         x = x + pos
-        # Transformer expects batch dimension
+
+        # Transformer expects a batch dimension (sequence length, features)
         x = self.encoder(x.unsqueeze(0)).squeeze(0)
-        # Output head
+
+        # Final projection
         return self.head(x)


### PR DESCRIPTION
## Summary
- implement a patch-based TemporalTransformer with three encoder layers for lightweight frame sequence modeling
- wire the temporal transformer into the tracker for single-camera temporal context
- assess collision risks and propose route suggestions based on temporal features

## Testing
- `python -m py_compile temporal_transformer.py yolov12_tracker.py`
- `pip install torch==2.1.0` *(fails: Could not find a version that satisfies the requirement torch==2.1.0 (Tunnel connection failed: 403 Forbidden))*
- `python - <<'PY'
import torch
from temporal_transformer import TemporalTransformer
model = TemporalTransformer()
print(sum(p.numel() for p in model.parameters()))
seq = torch.randn(8, 3, 64, 64)
print('input', seq.shape)
out = model(seq)
print('output', out.shape)
PY` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688dc3aa69b88333976f6623a38000fa