### PR TITLE
Enable immediate speech playback from queue

### DIFF
--- a/yolov12_tracker.py
+++ b/yolov12_tracker.py
@@ -254,10 +254,7 @@ def main(video_path, yolo_model, midas_model, midas_transform, device, output_vi
 
         is_detection_frame = (raw_frame_idx % frame_skip == 0)
         if not is_detection_frame:
-
-        is_detection_frame = (raw_frame_idx % frame_skip == 0)
-        if not is_detection_frame:
-          continue
+            continue
 
         frame_count += 1
 
@@ -556,6 +553,7 @@ def main(video_path, yolo_model, midas_model, midas_transform, device, output_vi
 
                 if should_speak:
                     speech_mgr.enqueue(alert_message)
+                    speech_mgr.play_next_if_available()
                     last_alert_time = current_time
                     last_spoken_alert_message = alert_message
                     last_effective_danger_level = current_frame_effective_level


### PR DESCRIPTION
## Summary
- Add `play_next_if_available` to `SpeechQueueManager` to pop and speak messages with a new `pyttsx3` engine
- Trigger speech queue playback directly in `yolov12_tracker` after cooldown checks

## Testing
- `python -m py_compile speak_queue_manager.py yolov12_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_688e2396fc808333ba73a2a36204161e