### PR TITLE
Avoid reinitializing pyttsx3 engine in SpeechQueueManager

### DIFF
--- a/speak_queue_manager.py
+++ b/speak_queue_manager.py
@@ -73,12 +73,8 @@ class SpeechQueueManager:
 
         if item:
             try:
-                engine = pyttsx3.init()
-                self._setup_voice(engine)
-                engine.setProperty('rate', 180)
-                engine.setProperty('volume', 0.9)
-                engine.say(item.message)
-                engine.runAndWait()
+                self.engine.say(item.message)
+                self.engine.runAndWait()
                 print(f"[✅ Speech] {item.message}")
             except Exception as e:
                 print(f"[Speech Error] {e}")


### PR DESCRIPTION
## Summary
- reuse the existing `self.engine` in `SpeechQueueManager.play_next_if_available`

## Testing
- `pytest`
- `python -m py_compile speak_queue_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68903f29d0548333b86d0546d86d98db