### PR TITLE
docs: add usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
-# Blind_guide_system
+# 盲人導引系統
+
+本專案展示一個以影片為基礎的輔助流程，透過 **YOLOv12** 偵測障礙與交通號誌、使用 **MiDaS** 估計距離，並搭配 **SORT** 追蹤物體，最後由 `pyttsx3` 發出語音提醒。
+
+## 安裝步驟
+
+1. 建立並啟用 Python 3.8 以上的虛擬環境。
+2. 安裝必要套件：
+
+   ```bash
+   pip install torch ultralytics opencv-python pyttsx3 pillow numpy
+   ```
+
+## 使用方式
+
+1. **準備資源**
+   - 下載並將 YOLOv12 權重路徑填入 `yolov12_tracker.py` 內的 `YOUR_YOLOV12_WEIGHTS`。
+   - 將待分析的影片放在資料夾中，並設定 `VIDEO_FOLDER_PATH` 為該路徑。
+
+2. **執行程式**
+
+  ```bash
+  python yolov12_tracker.py
+  ```
+
+   程式會載入模型、處理資料夾內的每支影片、追蹤物體、估計深度並透過語音提示障礙物及交通號誌。
+
+3. **使用圖形介面**
+
+   若希望直接透過視覺化介面操作，可執行：
+
+   ```bash
+   python blind_guide_app.py
+   ```
+
+   介面提供兩種模式：
+
+   - **影片偵測**：選取單支影片進行處理。
+   - **即時偵測**：啟用攝影機進行即時分析。
+
+   選擇「影片偵測」時需另行指定影片檔案，按下「開始偵測」後即會載入 YOLO 與 MiDaS 權重並運行主流程。
+
+## 參數調整
+
+所有參數都集中在 `yolov12_tracker.py` 末端的「設定區塊」，可依需求修改：
+
+- **路徑相關**
+  - `YOUR_YOLOV12_WEIGHTS`：YOLOv12 權重檔路徑。
+  - `VIDEO_FOLDER_PATH`：欲處理的影片資料夾。
+  - `OUTPUT_VIDEO_PATH`：若要儲存加上標註的輸出影片，填入檔案路徑；預設為 `None` 表示不儲存。
+
+- **偵測與追蹤**
+  - `CONF_THRESHOLD`：偵測信心閾值，介於 0~1，值越高偵測越嚴格。
+  - `IOU_THRESHOLD`：NMS 的 IoU 閾值，用來過濾重疊框。
+  - `YOLO_IMGSZ`：YOLO 的輸入尺寸，可設為 640 或 `"auto"`。
+  - `SORT_MAX_AGE` / `SORT_MIN_HITS` / `SORT_IOU_THRESHOLD`：SORT 追蹤器的追蹤條件與壽命控制。
+  - `PROCESS_FPS`：將輸入影片降採樣到指定 FPS 進行運算。
+
+- **深度估測**
+  - `MIDAS_MODEL_TYPE`：MiDaS 模型類型，如 `"DPT_Hybrid"`、`"DPT_Large"`、`"MiDaS_small"`。
+  - `MIDAS_OUTPUT_SCALE_FACTOR`：調整深度圖輸出大小的比例。
+  - `MIDAS_K_CONVERT` / `MIDAS_C_CONVERT`：將 MiDaS 深度值轉換成實際距離時使用的參數，可依實測調整校正。
+
+- **警示相關**
+  - `OBSTACLE_ALERT_DISTANCE`：靜態障礙物的語音提醒距離（公尺）。
+  - `MAIN_PATH_CENTER_WIDTH_PERCENTAGE`：只對畫面中央一定寬度範圍內的物體發出語音提醒，0.4 代表中間 40%。
+  - `VOICE_ALERT_COOLDOWN_OBSTACLE` / `VOICE_ALERT_COOLDOWN_LIGHT`：語音提示的冷卻時間（秒）。
+
+## 專案架構
+
+| 檔案 | 說明 |
+|------|------|
+| `yolov12_tracker.py` | 主流程：偵測、追蹤、深度估測與語音提示。 |
+| `sort.py` | SORT 多目標追蹤演算法。 |
+| `temporal_transformer.py` | 取得影格的時序特徵。 |
+| `speak_queue_manager.py` | 管理語音佇列與播報。 |
+
+## 注意事項
+
+- 首次執行時 `torch.hub` 會下載 MiDaS 模型，需要網路連線。
+- 若需語音提示請確認系統有可用的音訊輸出裝置。
+

--- a/blind_guide_app.py
+++ b/blind_guide_app.py
@@ -1,0 +1,99 @@
+import os
+import threading
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+import torch
+
+# Import detection pipeline
+from yolov12_tracker import main as run_pipeline, load_yolov12_model
+
+# Default model settings
+YOLO_WEIGHTS_PATH = os.path.join('weights', 'best.pt')
+MIDAS_MODEL_TYPE = 'DPT_Hybrid'
+
+
+def load_midas(model_type, device):
+    """Load MiDaS model and corresponding transforms."""
+    midas = torch.hub.load('intel-isl/MiDaS', model_type)
+    midas.to(device)
+    midas.eval()
+    transforms = torch.hub.load('intel-isl/MiDaS', 'transforms')
+    if model_type in ['DPT_Large', 'DPT_Hybrid']:
+        transform = transforms.dpt_transform
+    else:
+        transform = transforms.small_transform
+    return midas, transform
+
+
+class BlindGuideApp:
+    def __init__(self, master):
+        self.master = master
+        master.title('盲人導盲系統')
+
+        self.mode = tk.StringVar(value='video')
+        self.video_path = ''
+
+        mode_frame = tk.LabelFrame(master, text='選擇模式')
+        mode_frame.pack(padx=10, pady=10, fill='x')
+
+        tk.Radiobutton(mode_frame, text='影片偵測', variable=self.mode, value='video',
+                       command=self._toggle_video_button).pack(anchor='w')
+        tk.Radiobutton(mode_frame, text='即時偵測', variable=self.mode, value='realtime',
+                       command=self._toggle_video_button).pack(anchor='w')
+
+        file_frame = tk.Frame(master)
+        file_frame.pack(padx=10, pady=5, fill='x')
+        self.select_btn = tk.Button(file_frame, text='選擇影片', command=self._choose_video)
+        self.select_btn.pack(side='left')
+        self.file_label = tk.Label(file_frame, text='未選擇任何檔案', anchor='w')
+        self.file_label.pack(side='left', padx=5)
+
+        action_frame = tk.Frame(master)
+        action_frame.pack(padx=10, pady=10)
+        tk.Button(action_frame, text='開始偵測', command=self.start_detection).pack(side='left', padx=5)
+        tk.Button(action_frame, text='離開', command=master.quit).pack(side='left', padx=5)
+
+        self._toggle_video_button()
+
+    def _toggle_video_button(self):
+        if self.mode.get() == 'video':
+            self.select_btn.config(state='normal')
+        else:
+            self.select_btn.config(state='disabled')
+
+    def _choose_video(self):
+        path = filedialog.askopenfilename(title='選擇影片',
+                                          filetypes=[('Video files', '*.mp4 *.avi *.mov *.mkv *.flv *.wmv')])
+        if path:
+            self.video_path = path
+            self.file_label.config(text=os.path.basename(path))
+
+    def start_detection(self):
+        mode = self.mode.get()
+        if mode == 'video' and not self.video_path:
+            messagebox.showerror('錯誤', '請先選擇影片檔案')
+            return
+        threading.Thread(target=self._run_detection, daemon=True).start()
+
+    def _run_detection(self):
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        yolo_model = load_yolov12_model(YOLO_WEIGHTS_PATH)
+        if yolo_model is None:
+            messagebox.showerror('錯誤', f'無法載入 YOLO 權重: {YOLO_WEIGHTS_PATH}')
+            return
+        midas_model, midas_transform = load_midas(MIDAS_MODEL_TYPE, device)
+        source = 0 if self.mode.get() == 'realtime' else self.video_path
+        run_pipeline(
+            video_path=source,
+            yolo_model=yolo_model,
+            midas_model=midas_model,
+            midas_transform=midas_transform,
+            device=device,
+        )
+
+
+if __name__ == '__main__':
+    root = tk.Tk()
+    app = BlindGuideApp(root)
+    root.mainloop()


### PR DESCRIPTION
## Summary
- add detailed Chinese instructions and parameter descriptions for configuring the video pipeline
- provide a GUI script to choose between real-time and video detection modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68903e82950083339a0bb51d0bd2b4d7