### PR TITLE
fix: use relative path for YOLO weights

### DIFF
--- a/blind_guide_app.py
+++ b/blind_guide_app.py
@@ -9,7 +9,8 @@ import torch
 from yolov12_tracker import main as run_pipeline, load_yolov12_model
 
 # Default model settings
-YOLO_WEIGHTS_PATH = os.path.join('weights', 'best.pt')
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+YOLO_WEIGHTS_PATH = os.path.join(BASE_DIR, 'weights', 'best.pt')
 MIDAS_MODEL_TYPE = 'DPT_Hybrid'
 
 


### PR DESCRIPTION
## Summary
- ensure YOLOv12 weights are loaded from local `weights/best.pt`

## Testing
- `python -m py_compile blind_guide_app.py yolov12_tracker.py sort.py speak_queue_manager.py temporal_transformer.py`


------
https://chatgpt.com/codex/tasks/task_e_68905a411f788333924bfeddf4e7c3a0