### PR TITLE
feat: embed video display in main window

### DIFF
--- a/blind_guide_app.py
+++ b/blind_guide_app.py
@@ -3,13 +3,16 @@ import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox
 
+import cv2
+from PIL import Image, ImageTk
 import torch
 
 # Import detection pipeline
 from yolov12_tracker import main as run_pipeline, load_yolov12_model
 
 # Default model settings
-YOLO_WEIGHTS_PATH = os.path.join('weights', 'best.pt')
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+YOLO_WEIGHTS_PATH = os.path.join(BASE_DIR, 'weights', 'best.pt')
 MIDAS_MODEL_TYPE = 'DPT_Hybrid'
 
 
@@ -54,6 +57,10 @@ class BlindGuideApp:
         tk.Button(action_frame, text='開始偵測', command=self.start_detection).pack(side='left', padx=5)
         tk.Button(action_frame, text='離開', command=master.quit).pack(side='left', padx=5)
 
+        # Image display placeholder
+        self.image_label = tk.Label(master)
+        self.image_label.pack(padx=10, pady=10)
+
         self._toggle_video_button()
 
     def _toggle_video_button(self):
@@ -90,7 +97,18 @@ class BlindGuideApp:
             midas_model=midas_model,
             midas_transform=midas_transform,
             device=device,
+            display_callback=self._display_frame,
         )
+
+    def _display_frame(self, frame):
+        img_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        img = Image.fromarray(img_rgb)
+        imgtk = ImageTk.PhotoImage(image=img)
+        self.master.after(0, self._update_image_label, imgtk)
+
+    def _update_image_label(self, imgtk):
+        self.image_label.imgtk = imgtk
+        self.image_label.config(image=imgtk)
 
 
 if __name__ == '__main__':

--- a/yolov12_tracker.py
+++ b/yolov12_tracker.py
@@ -165,7 +165,9 @@ def main(video_path, yolo_model, midas_model, midas_transform, device, output_vi
            DANGER_RESET_COOLDOWN=2.0,
            # Screen display parameters
            screen_width=1920,
-           screen_height=1080
+           screen_height=1080,
+           # Optional callback for external frame display
+           display_callback=None
            ):
 
     # Initialize SORT tracker (moved inside main as it's stateful per video)
@@ -573,11 +575,13 @@ def main(video_path, yolo_model, midas_model, midas_transform, device, output_vi
         display_width_scaled = int(display_width_current * scale * 0.4) # Adjusted for better view on common screens
         display_height_scaled = int(display_height_current * scale * 0.4)
 
-        window_name = "Obstacle Detection and Alert for Visually Impaired"
-        cv2.namedWindow(window_name, cv2.WINDOW_NORMAL)
-        cv2.resizeWindow(window_name, display_width_scaled, display_height_scaled)
-
-        cv2.imshow(window_name, combined_output_frame)
+        if display_callback:
+            display_callback(combined_output_frame)
+        else:
+            window_name = "Obstacle Detection and Alert for Visually Impaired"
+            cv2.namedWindow(window_name, cv2.WINDOW_NORMAL)
+            cv2.resizeWindow(window_name, display_width_scaled, display_height_scaled)
+            cv2.imshow(window_name, combined_output_frame)
 
         if out:
             if combined_output_frame.shape[1] != output_video_width or \
@@ -587,13 +591,14 @@ def main(video_path, yolo_model, midas_model, midas_transform, device, output_vi
             else:
                 out.write(combined_output_frame)
 
-        if cv2.waitKey(1) & 0xFF == ord('q'):
+        if display_callback is None and cv2.waitKey(1) & 0xFF == ord('q'):
             break
 
     cap.release()
     if out:
         out.release()
-    cv2.destroyAllWindows()
+    if display_callback is None:
+        cv2.destroyAllWindows()
     print(f"Video: {video_path} processing complete.")
 
 


### PR DESCRIPTION
## Summary
- ensure YOLOv12 weights are loaded from local `weights/best.pt`
- embed detection frames in the main Tk window to avoid extra OpenCV windows

## Testing
- `python -m py_compile blind_guide_app.py yolov12_tracker.py sort.py speak_queue_manager.py temporal_transformer.py`


------
https://chatgpt.com/codex/tasks/task_e_68905a411f788333924bfeddf4e7c3a0