### PR TITLE
refactor: move speech to main thread

### DIFF
--- a/blind_guide_app.py
+++ b/blind_guide_app.py
@@ -9,6 +9,7 @@ import torch
 
 # Import detection pipeline
 from yolov12_tracker import main as run_pipeline, load_yolov12_model
+from speak_queue_manager import SpeechQueueManager
 
 # Default model settings
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -63,6 +64,10 @@ class BlindGuideApp:
 
         self._toggle_video_button()
 
+        # Initialize speech manager on main thread
+        self.speech_mgr = SpeechQueueManager()
+        self._schedule_speech()
+
     def _toggle_video_button(self):
         if self.mode.get() == 'video':
             self.select_btn.config(state='normal')
@@ -98,6 +103,7 @@ class BlindGuideApp:
             midas_transform=midas_transform,
             device=device,
             display_callback=self._display_frame,
+            speech_mgr=self.speech_mgr,
         )
 
     def _display_frame(self, frame):
@@ -109,6 +115,10 @@ class BlindGuideApp:
     def _update_image_label(self, imgtk):
         self.image_label.imgtk = imgtk
         self.image_label.config(image=imgtk)
+
+    def _schedule_speech(self):
+        self.speech_mgr.process_queue()
+        self.master.after(100, self._schedule_speech)
 
 
 if __name__ == '__main__':

--- a/yolov12_tracker.py
+++ b/yolov12_tracker.py
@@ -18,9 +18,6 @@ from temporal_transformer import TemporalTransformer
 # Uses single-camera frames for temporal context.
 transformer = TemporalTransformer()
 
-# Global speech queue manager
-speech_mgr = SpeechQueueManager()
-
 
 def yolov12_detect(model, img, conf_threshold, iou_threshold, target_classes=None, imgsz=640):
     """
@@ -167,7 +164,8 @@ def main(video_path, yolo_model, midas_model, midas_transform, device, output_vi
            screen_width=1920,
            screen_height=1080,
            # Optional callback for external frame display
-           display_callback=None
+           display_callback=None,
+           speech_mgr: SpeechQueueManager | None = None
            ):
 
     # Initialize SORT tracker (moved inside main as it's stateful per video)
@@ -546,8 +544,8 @@ def main(video_path, yolo_model, midas_model, midas_transform, device, output_vi
                         should_speak = True
 
                 if should_speak:
-                    speech_mgr.enqueue(alert_message)
-                    speech_mgr.play_next_if_available()
+                    if speech_mgr:
+                        speech_mgr.enqueue(alert_message)
                     last_alert_time = current_time
                     last_spoken_alert_message = alert_message
                     last_effective_danger_level = current_frame_effective_level


### PR DESCRIPTION
## Summary
- refactor speech queue to run pyttsx3 on main thread via `process_queue`
- manage speech playback from Tkinter app and pass queue to detection
- allow detection pipeline to enqueue messages without playing audio

## Testing
- `python -m py_compile speak_queue_manager.py yolov12_tracker.py blind_guide_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6892ebb438ac8333b1eeacffe7dd2033